### PR TITLE
fix: scrolling text incorrectly wrapping

### DIFF
--- a/src/app/scrollable-text/index.css
+++ b/src/app/scrollable-text/index.css
@@ -1,6 +1,7 @@
 .scrollable-text {
   overflow: hidden;
   position: relative;
+  white-space: nowrap;
 }
 
 .scrollable-text--scrolling:after {


### PR DESCRIPTION
There's a rare edge case where the text incorrectly renders:

![image](https://github.com/user-attachments/assets/2be29fbb-f59f-48a2-807a-b9332b10e91b)

This fixes that
